### PR TITLE
Fix an issue with <ol>s nested inside <ul>s.

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -559,6 +559,10 @@ ul {
   list-style-image: url("../images/bullet.png");
 }
 
+ol {
+  list-style-image: none;
+}
+
 strong {
   font-weight: bold;
   color: #333;


### PR DESCRIPTION
If you have an `<ol>` tag nested inside a `<ul>` tag, the `<ol>` tag will have bullets instead of numbers. This fixes that by resetting `<ol>`'s list image to "none".

I encountered this bug at a tweaked version of this theme that I'm using at http://haikuarchives.github.io/uploadrepo.html.
