### PR TITLE
Add default font fallback to $code

### DIFF
--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -19,4 +19,4 @@ $base-margin: 10px;
 $bold: bold;
 $serif: 'Copse', "Helvetica Neue", Helvetica, Arial, sans-serif;
 $sans: 'Noto Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
-$code: 'Lucida Sans', Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
+$code: 'Lucida Sans', Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, monospace;


### PR DESCRIPTION
Before it was falling back (for me) to Times New Roman, which just looks bad on code.